### PR TITLE
Ensure script exits with failure status on failure

### DIFF
--- a/kerbrute/main.py
+++ b/kerbrute/main.py
@@ -123,6 +123,7 @@ def main():
 
     if not kerberos_bruter.some_password_was_discovered():
         logging.info("No passwords were discovered :'(")
+        sys.exit(1)
 
 
 class KerberosBruter:


### PR DESCRIPTION
To make this script easily wrappable by other scripts, it should return a failure status when it fails so that logic like the following can work:

```bash
# inside loop that iterates through computers in an AD OU
if kerbrute -domain "${DOMNAME}" -user "${COMPNAME}\$" -password "${COMPNAME:0:14}" -dc-ip $DCIP; then
  echo "${COMPNAME} - VULNERABLE - Pre2k default password" | tee -a $OUTFILE
elif kerbrute -domain "${DOMNAME}" -user "${COMPNAME}\$" -password "" -dc-ip $DCIP; then
  echo "${COMPNAME} - VULNERABLE - Blank default password" | tee -a $OUTFILE
fi
```